### PR TITLE
Multiple CA and Token fix

### DIFF
--- a/src/ocspd/response.c
+++ b/src/ocspd/response.c
@@ -670,8 +670,8 @@ CA_LIST_ENTRY *OCSPD_CA_ENTRY_find(OCSPD_CONFIG *conf, OCSP_CERTID *cid)
 			{
 				PKI_log_debug("CRL::CA [%s] nameHash mismatch (%d)", 
 					ca->ca_id, ret);
-				continue;
 			}
+			continue;
 		}
 		else if( conf->debug ) 
 		{
@@ -684,8 +684,9 @@ CA_LIST_ENTRY *OCSPD_CA_ENTRY_find(OCSPD_CONFIG *conf, OCSP_CERTID *cid)
 			{
 				PKI_log_debug("CRL::CA [%s] issuerKeyHash mismatch (%d)",
 				 	ca->ca_id, ret);
-				continue;
 			}
+			continue;
+
 		}
 		else if (conf->debug) 
 		{


### PR DESCRIPTION
This pull request supplies 2 patches. 

```
 The first patch was submitted by Sylvain Munaut (http://sourceforge.net/p/openca/mailman/message/32812416/) and fixes multiple token handling. (SHA1: e6dd747e556f4c968d11f7cbd06c1e2692cacc18 ).

 The second patch was submitted by me and fixes the CA selection logic; due to 2 misplaced continue statements, CA selection would only work when run with -debug. (SHA1: 10a64457107462a111148d43b7ca85e2a45383f4)
```
