### PR TITLE
Implementet check of mtime for CRLs to avoid unnecessary reload

### DIFF
--- a/etc/ocspd.xml.in
+++ b/etc/ocspd.xml.in
@@ -23,6 +23,8 @@
       <pki:crlReloadExpired>yes</pki:crlReloadExpired>
       <!-- Check CRLs validity every x seconds -->
       <pki:crlCheckValidity>600</pki:crlCheckValidity>
+      <!-- Skip CRL reload if it was not modified after the last load -->
+      <pki:crlCheckModificationTime>no</pki:crlCheckModificationTime>
    </pki:general>
    <!-- Security Related Configurations -->
    <pki:security>

--- a/etc/ocspd.xml.in
+++ b/etc/ocspd.xml.in
@@ -53,6 +53,13 @@
    <pki:response>
       <!-- Max size of incoming requests -->
       <pki:maxReqSize>8192</pki:maxReqSize>
+      <!-- Digest Algorithm used for building the issuerNameHash and
+           issuerKeyHash digest. More than one value can be used:
+           e.g. >SHA1,SHA224,SHA256,SHA384,SHA512<
+           The algorithms must be given in capital letters. Every algorithm
+           supported by OpenSSL can be used.
+           If not configured the digestAlgorithm (see below) ist used. -->
+      <pki:issuerHashDigestAlgorithm>SHA1,SHA256</pki:issuerHashDigestAlgorithm>
       <!-- Digest Algorithm to be used when building responses, currently
            the standard specifies SHA1 as the only supported algorithm -->
       <pki:digestAlgorithm>SHA1</pki:digestAlgorithm>

--- a/src/ocspd/config.c
+++ b/src/ocspd/config.c
@@ -19,6 +19,22 @@
 extern OCSPD_CONFIG * ocspd_conf;
 
 /* Functions */
+static int OCSPD_EVP_MD_STACK_add_md(STACK_OF(EVP_MD) **mds, const EVP_MD *md)
+{
+	if (!mds)
+		return 0;
+
+	/* Create new md stack if necessary. */
+	if (!*mds && !(*mds = sk_EVP_MD_new_null()))
+		return 0;
+
+	/* Add the shared md, no copy needed. */
+	if (!sk_EVP_MD_push(*mds, (EVP_MD *)md))
+		return 0;
+
+	return 1;
+}
+
 OCSPD_CONFIG * OCSPD_load_config(char *configfile)
 {
 	OCSPD_CONFIG *h = NULL;
@@ -300,6 +316,68 @@ OCSPD_CONFIG * OCSPD_load_config(char *configfile)
 		PKI_Free(tmp_s);
 	}
 
+	/* Digest algorithm used for building the issuerNameHash and issuerKeyHash */
+	if((tmp_s = PKI_CONFIG_get_value( cnf,
+			"/serverConfig/response/issuerHashDigestAlgorithm" )) != NULL )
+	{
+		EVP_MD *digest;
+		char *p1, *p2;
+
+		p1 = tmp_s;
+
+		while( (p2 = strchr(p1, ',') ) != NULL)
+		{
+			*p2++ = 0;
+
+			digest = PKI_DIGEST_ALG_get_by_name( p1 );
+			if (!digest)
+			{
+				PKI_log_err("Can not parse issuerHashDigestAlgorithm: %s", p1);
+				goto err;
+			}
+
+			if(!OCSPD_EVP_MD_STACK_add_md(&(h->issuerHashDigest), digest))
+			{
+				PKI_log_err("Can not add issuerHashDigestAlgorithm");
+				goto err;
+			}
+
+			PKI_log_debug("Selected issuerHashDigestAlgorithm: %s", p1);
+
+			/* Skip possible spaces */
+			while(*p2 == ' ')
+				p2++;
+			p1 = p2;
+		}
+
+		digest = PKI_DIGEST_ALG_get_by_name( p1 );
+		if (!digest)
+		{
+			PKI_log_err("Can not parse issuerHashDigestAlgorithm: %s", p1);
+			goto err;
+		}
+
+		if(!OCSPD_EVP_MD_STACK_add_md(&(h->issuerHashDigest), digest))
+		{
+			PKI_log_err("Can not add issuerHashDigestAlgorithm: %s", p1);
+			goto err;
+		}
+
+		PKI_log_debug("Selected issuerHashDigestAlgorithm: %s", p1);
+		PKI_Free(tmp_s);
+	}
+	else
+	{
+		/* for backward compatibility we use the configured digestAlgorithm */
+		if(!OCSPD_EVP_MD_STACK_add_md(&(h->issuerHashDigest), h->digest))
+		{
+			PKI_log_err("Can not add issuerHashDigestAlgorithm: %s", EVP_MD_name(PKI_DIGEST_ALG_DEFAULT));
+			goto err;
+		}
+
+		PKI_log_debug("Selected issuerHashDigestAlgorithm: %s", EVP_MD_name(PKI_DIGEST_ALG_DEFAULT));
+	}
+
 	/* Now Parse the PRQP Response Section */
 	if ((tmp_s = PKI_CONFIG_get_value( cnf, "/serverConfig/response/validity/days" )) != NULL)
 	{
@@ -468,7 +546,13 @@ int OCSPD_build_ca_list ( OCSPD_CONFIG *handler,
 		tmp_url = NULL;
 
 		ca->ca_id = PKI_CONFIG_get_value( cnf, "/caConfig/name" );
-		ca->cid = CA_ENTRY_CERTID_new ( ca->ca_cert, handler->digest );
+
+		ca->sk_cid = CA_ENTRY_CERTID_new_sk ( ca->ca_cert, handler->issuerHashDigest );
+		if(ca->sk_cid == NULL) {
+			PKI_log_err ( "Cannot build CA CertIDs");
+			continue;
+		}
+
 
 		/* Get the CRL URL and the CRL itself */
 		if((tmp_s = PKI_CONFIG_get_value(cnf, "/caConfig/crlUrl")) == NULL)
@@ -725,12 +809,11 @@ int ocspd_reload_all_ca ( OCSPD_CONFIG *conf ) {
 					ca->ca_id );
 		}
 
-		if((ca->cid = CA_ENTRY_CERTID_new ( ca->ca_cert,
-						conf->digest)) == NULL ) {
+		ca->sk_cid = CA_ENTRY_CERTID_new_sk ( ca->ca_cert, conf->issuerHashDigest );
+		if(ca->sk_cid == NULL ) {
 			PKI_log_err( "CA List structure init error (CERTID).");
 			continue;
 		}
-
 	}
 
 	return 1;
@@ -797,7 +880,16 @@ void CA_LIST_ENTRY_free ( CA_LIST_ENTRY *ca ) {
 	}
 
 	if ( ca->ca_cert ) PKI_X509_CERT_free ( ca->ca_cert );
-	if ( ca->cid ) CA_ENTRY_CERTID_free ( ca->cid );
+	if ( ca->sk_cid )
+	{
+		CA_ENTRY_CERTID *cid;
+
+		while ((cid = sk_CA_ENTRY_CERTID_pop ( ca->sk_cid )) != NULL)
+		{
+			CA_ENTRY_CERTID_free ( cid );
+		}
+		sk_CA_ENTRY_CERTID_free ( ca->sk_cid );
+	}
 	if ( ca->ca_url ) URL_free ( ca->ca_url );
 	if ( ca->crl_url ) URL_free ( ca->crl_url );
 
@@ -832,11 +924,11 @@ CA_LIST_ENTRY * OCSPD_ca_entry_new ( OCSPD_CONFIG *handler,
 	if (( ret = PKI_Malloc ( sizeof( CA_LIST_ENTRY ) )) == NULL ) return NULL;
 
 	/* Let's get the CA_ENTRY_CERTID */
-	if ((ret->cid = CA_ENTRY_CERTID_new ( x, handler->digest )) == NULL)
-	{
+	ret->sk_cid = CA_ENTRY_CERTID_new_sk ( x, handler->issuerHashDigest );
+	if(ret->sk_cid == NULL ) {
 		CA_LIST_ENTRY_free ( ret );
-		return NULL;
-	}
+		return ( NULL );
+ 	}
 
 	return ret;
 
@@ -844,27 +936,36 @@ CA_LIST_ENTRY * OCSPD_ca_entry_new ( OCSPD_CONFIG *handler,
 
 /* ---------------------------- CA_ENTRY_CERTID ------------------------- */
 
-CA_ENTRY_CERTID * CA_ENTRY_CERTID_new ( PKI_X509_CERT *cert, 
-					PKI_DIGEST_ALG * digestAlg ) {
+STACK_OF(CA_ENTRY_CERTID) * CA_ENTRY_CERTID_new_sk ( PKI_X509_CERT *cert,
+					STACK_OF(EVP_MD) *mds ) {
 
-	CA_ENTRY_CERTID *ret = NULL;
+	int i;
+	STACK_OF(CA_ENTRY_CERTID) *sk_cid = NULL;
+	CA_ENTRY_CERTID *cid = NULL;
 
 	PKI_STRING *keyString = NULL;
 	PKI_DIGEST *keyDigest = NULL;
 
 	PKI_X509_NAME *iName = NULL;
 	PKI_DIGEST *nameDigest = NULL;
+	STACK_OF(EVP_MD) *sk_md = NULL;
+
+
+	PKI_log_debug("Building CA_ENTRY_CERTID stack");
 
 	/* Check for needed info */
 	if ( !cert || !cert->value ) return NULL;
 
-	/* Use SHA1 as default digest algorithm */
-	if ( !digestAlg ) digestAlg = PKI_DIGEST_ALG_SHA1;
+	/* fallback */
+	if ( !mds )
+	{
+		if(!OCSPD_EVP_MD_STACK_add_md(&(sk_md), PKI_DIGEST_ALG_SHA1))
+		{
+			PKI_log_err("Can not add digest algorithm");
+			return (NULL);
+		}
 
-	// Allocate Memory for the CA_ENTRY_CERTID
-	if((ret = PKI_Malloc(sizeof(CA_ENTRY_CERTID))) == NULL) {
-		PKI_ERROR(PKI_ERR_MEMORY_ALLOC, NULL);
-		goto err;
+		mds = sk_md; // use input parameter as temporary variable
 	}
 
 	/* Retrieves the subject name from the certificate */
@@ -874,57 +975,94 @@ CA_ENTRY_CERTID * CA_ENTRY_CERTID_new ( PKI_X509_CERT *cert,
 		goto err;
 	};
 
-	// Let's build the HASH of the Name
-	if((nameDigest = PKI_X509_NAME_get_digest(iName, digestAlg)) == NULL) {
-		PKI_log_err("Can not get digest string from certificate's subject");
-		goto err;
-	};
-
-	// Assign the new OCTET string tothe nameHash field
-	if (( ret->nameHash = PKI_STRING_new ( PKI_STRING_OCTET,
-			(char *) nameDigest->digest, (ssize_t) nameDigest->size )) == NULL ) {
-		PKI_log_err("Can not assign nameHash to CERTID");
-		goto err;
-	};
-	
 	// Let's get the key bitstring from the certificate
 	if (( keyString = PKI_X509_CERT_get_data( cert, 
 				PKI_X509_DATA_PUBKEY_BITSTRING)) == NULL ) {
 		PKI_log_err("Can not get certificate's pubkey bitstring");
 		goto err;
+	}
 
-	} else {
+	// generate a digest for each given hash algorithm
+	for (i = 0; i < sk_EVP_MD_num(mds); ++i) {
+
+		EVP_MD *md = NULL;
+
+		// Allocate Memory for the CA_ENTRY_CERTID stack
+		if (!sk_cid && (sk_cid = sk_CA_ENTRY_CERTID_new_null()) == NULL) {
+			PKI_ERROR(PKI_ERR_MEMORY_ALLOC, NULL);
+			goto err;
+		}
+
+		md = sk_EVP_MD_value(mds, i);
+		if(!md)
+			continue;
+
+		PKI_log_debug("Selected issuerHashDigestAlgorithm: %s", EVP_MD_name(md));
+
+		// Allocate Memory for each CA_ENTRY_CERTID
+		if((cid = PKI_Malloc(sizeof(CA_ENTRY_CERTID))) == NULL) {
+			PKI_ERROR(PKI_ERR_MEMORY_ALLOC, NULL);
+			goto err;
+		}
+
+		// Let's build the HASH of the Name
+		if((nameDigest = PKI_X509_NAME_get_digest(iName, md)) == NULL) {
+			PKI_log_err("Can not get digest string from certificate's subject");
+			goto err;
+		}
+
+		// Assign the new OCTET string to the nameHash field
+		if (( cid->nameHash = PKI_STRING_new ( PKI_STRING_OCTET,
+				(char *)nameDigest->digest, (ssize_t) nameDigest->size )) == NULL ) {
+			PKI_log_err("Can not assign nameHash to CERTID");
+			goto err;
+		};
+
 		// We build the keyDigest from the keyString
-		if((keyDigest = PKI_STRING_get_digest (keyString, 
-				digestAlg)) == NULL ) {
+		if((keyDigest = PKI_STRING_get_digest (keyString, md)) == NULL ) {
 			PKI_log_err("Can not create new keyDigest from keyString");
 			goto err;
 		};
-	};
 
-	if((ret->keyHash = PKI_STRING_new ( PKI_STRING_OCTET,
-				(char *) keyDigest->digest, (ssize_t) keyDigest->size )) == NULL ) {
-		PKI_log_err("Can not assign keyHash to CERTID");
-		goto err;
-	};
+		if((cid->keyHash = PKI_STRING_new ( PKI_STRING_OCTET,
+						(char *)keyDigest->digest, (ssize_t) keyDigest->size )) == NULL ) {
+			PKI_log_err("Can not assign keyHash to CERTID");
+			goto err;
+		}
 
-	/* Set the Digest Algorithm used */
-	if((ret->hashAlgorithm = PKI_ALGORITHM_new_digest( digestAlg )) == NULL ) {
-		if( ret ) CA_ENTRY_CERTID_free ( ret );
-		PKI_log_err("ERROR, can not create a new hashAlgorithm!");
-		return NULL;
-	};
+		/* Set the Digest Algorithm used */
+		if((cid->hashAlgorithm = PKI_ALGORITHM_new_digest( md )) == NULL ) {
+			PKI_log_err("ERROR, can not create a new hashAlgorithm!");
+			goto err;
+		}
 
-	if ( nameDigest ) PKI_DIGEST_free ( nameDigest );
-	if ( keyDigest  ) PKI_DIGEST_free ( keyDigest );
+		// add entry to our stack
+		if(!sk_CA_ENTRY_CERTID_push(sk_cid, cid)) {
+			PKI_log_err("ERROR, can not create a new hashAlgorithm!");
+			goto err;
+		}
+		cid = NULL;
 
-	return ret;
+		if ( nameDigest ) {
+			PKI_DIGEST_free ( nameDigest );
+			nameDigest = NULL;
+		}
+		if ( keyDigest  ) {
+			PKI_DIGEST_free ( keyDigest );
+			keyDigest = NULL;
+		}
+	}
+
+	if ( sk_md ) sk_EVP_MD_free(sk_md);
+
+	return sk_cid;
 
 err:
 	if ( nameDigest ) PKI_DIGEST_free ( nameDigest );
 	if ( keyDigest  ) PKI_DIGEST_free ( keyDigest );
-
-	if ( ret ) CA_ENTRY_CERTID_free ( ret );
+	if ( sk_cid )     sk_CA_ENTRY_CERTID_free(sk_cid);
+	if ( cid )        CA_ENTRY_CERTID_free ( cid );
+	if ( sk_md )      sk_EVP_MD_free(sk_md);
 
 	return ( NULL );
 }
@@ -940,6 +1078,10 @@ void CA_ENTRY_CERTID_free ( CA_ENTRY_CERTID *cid ) {
 
 	if ( cid->nameHash ) {
 		PKI_STRING_free ( cid->nameHash );
+	}
+
+	if ( cid->hashAlgorithm ) {
+		X509_ALGOR_free(cid->hashAlgorithm);
 	}
 
 	PKI_Free ( cid );

--- a/src/ocspd/includes/configuration.h
+++ b/src/ocspd/includes/configuration.h
@@ -20,6 +20,10 @@
 
 #include "general.h"
 
+#if OPENSSL_VERSION_NUMBER >= 0x10000000L
+#include <openssl/ts.h>
+#endif
+
 OCSPD_CONFIG * OCSPD_load_config( char *configfile );
 
 int OCSPD_build_ca_list ( OCSPD_CONFIG *handler,
@@ -41,8 +45,8 @@ void CA_LIST_ENTRY_free ( CA_LIST_ENTRY *ca );
 CA_LIST_ENTRY * OCSPD_ca_entry_new ( OCSPD_CONFIG *handler,
 				PKI_X509_CERT *x, PKI_CONFIG *cnf );
 
-CA_ENTRY_CERTID * CA_ENTRY_CERTID_new ( PKI_X509_CERT *x, 
-				PKI_DIGEST_ALG * digest );
+STACK_OF(CA_ENTRY_CERTID) * CA_ENTRY_CERTID_new_sk ( PKI_X509_CERT *cert,
+				STACK_OF(EVP_MD) *mds );
 
 void CA_ENTRY_CERTID_free ( CA_ENTRY_CERTID *cid );
 

--- a/src/ocspd/includes/general.h
+++ b/src/ocspd/includes/general.h
@@ -166,6 +166,7 @@ typedef struct ca_list_st {
 	char *token_name;
 	char *token_config_dir;
 	PKI_TOKEN *token;
+	time_t mtime;
 	
 	/* Responder Identifier Type */
 	int response_id_type;
@@ -236,6 +237,7 @@ typedef struct ocspd_config {
 	int crl_check_validity;
 	int crl_auto_reload;
 	int crl_reload_expired;
+	int crl_check_mtime;
 
 	int current_crl_reload;
 	int current_crl_check;

--- a/src/ocspd/includes/general.h
+++ b/src/ocspd/includes/general.h
@@ -102,12 +102,26 @@ typedef struct ca_entry_certid
 	} CA_ENTRY_CERTID;
 
 #define sk_CA_ENTRY_CERTID_new_null() SKM_sk_new_null(CA_ENTRY_CERTID)
+#define sk_CA_ENTRY_CERTID_free(st) SKM_sk_free(CA_ENTRY_CERTID, (st))
 #define sk_CA_ENTRY_CERTID_push(st, val) SKM_sk_push(CA_ENTRY_CERTID, (st), (val))
 #define sk_CA_ENTRY_CERTID_pop(st) SKM_sk_pop(CA_ENTRY_CERTID, (st))
 #define sk_CA_ENTRY_CERTID_value(st, i) SKM_sk_value(CA_ENTRY_CERTID, (st), (i))
 #define sk_CA_ENTRY_CERTID_num(st) SKM_sk_num(CA_ENTRY_CERTID, (st))
 #define sk_CA_ENTRY_CERTID_sort(st) SKM_sk_sort(CA_ENTRY_CERTID, (st))
 #define sk_CA_ENTRY_CERTID_find(st) SKM_sk_find(CA_ENTRY_CERTID, (st))
+
+#if OPENSSL_VERSION_NUMBER < 0x10000000L
+DECLARE_STACK_OF(EVP_MD)
+DECLARE_ASN1_SET_OF(EVP_MD)
+#define sk_EVP_MD_new_null() SKM_sk_new_null(EVP_MD)
+#define sk_EVP_MD_free(st) SKM_sk_free(EVP_MD, (st))
+#define sk_EVP_MD_push(st, val) SKM_sk_push(EVP_MD, (st), (val))
+#define sk_EVP_MD_pop(st) SKM_sk_pop(EVP_MD, (st))
+#define sk_EVP_MD_value(st, i) SKM_sk_value(EVP_MD, (st), (i))
+#define sk_EVP_MD_num(st) SKM_sk_num(EVP_MD, (st))
+#define sk_EVP_MD_sort(st) SKM_sk_sort(EVP_MD, (st))
+#define sk_EVP_MD_find(st) SKM_sk_find(EVP_MD, (st))
+#endif
 
 /* List of available CAs */
 typedef struct ca_list_st {
@@ -121,7 +135,7 @@ typedef struct ca_list_st {
 	PKI_X509_CERT *ca_cert;
 
 	/* Cert Identifier */
-	CA_ENTRY_CERTID *cid;
+	STACK_OF(CA_ENTRY_CERTID) *sk_cid;
 
 	/* CA certificate URL */
 	URL *ca_url;
@@ -206,6 +220,7 @@ typedef struct ocspd_config {
 	char *chroot_dir;
 
 	/* Digest to be used */
+	STACK_OF(EVP_MD) *issuerHashDigest;
 	PKI_DIGEST_ALG *digest;
 	PKI_DIGEST_ALG *sigDigest;
 


### PR DESCRIPTION
To avoid unnecessary reload of unchanged CRLs the mtime of the file is checked for any update.
