### PR TITLE
add a semicolon at ca.d at etc/Makefile.in

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -19,7 +19,7 @@ install-data-local:
 	$(mkinstalldirs) $(etc_prefix)/ocspd/certs; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/crls; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/private; \
-	$(mkinstalldirs) $(etc_prefix)/ocspd/ca.d \
+	$(mkinstalldirs) $(etc_prefix)/ocspd/ca.d; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki/token.d; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki/hsm.d; \

--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -477,7 +477,7 @@ install-data-local:
 	$(mkinstalldirs) $(etc_prefix)/ocspd/certs; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/crls; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/private; \
-	$(mkinstalldirs) $(etc_prefix)/ocspd/ca.d \
+	$(mkinstalldirs) $(etc_prefix)/ocspd/ca.d; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki/token.d; \
 	$(mkinstalldirs) $(etc_prefix)/ocspd/pki/hsm.d; \


### PR DESCRIPTION
fixes an error trying to overwrite /bin/bash