### PR TITLE
Fix: Can not parse cert & coredump

### DIFF
--- a/src/ocspd/config.c
+++ b/src/ocspd/config.c
@@ -487,7 +487,7 @@ int OCSPD_build_ca_list ( OCSPD_CONFIG *handler,
 			subTmp_s = NULL;
 
 			// Retrieves the CA cert
-			if ((tmp_cert = PKI_X509_CERT_get_url(tmp_url, -1, NULL, NULL ))== NULL)
+			if ((tmp_cert = PKI_X509_CERT_get_url(tmp_url, PKI_DATA_FORMAT_UNKNOWN, NULL, NULL ))== NULL)
 			{
 				// Error, can not get the CA certificate from the
 				// provided URL in the configuration
@@ -524,7 +524,7 @@ int OCSPD_build_ca_list ( OCSPD_CONFIG *handler,
 			}
 
 			// Parses and get the stack of X509_CERT from the PKI_MEM data
-			if ((cc_sk = PKI_X509_CERT_STACK_get_mem(mm, -1, NULL)) == NULL) {
+			if ((cc_sk = PKI_X509_CERT_STACK_get_mem(mm, PKI_DATA_FORMAT_UNKNOWN, NULL)) == NULL) {
 
 				// Error, can not get the stack of certs from the CA cert value
 				PKI_log_err("Can not parse cert from /caConfig/caCertValue [CA: %s]",
@@ -745,7 +745,7 @@ int OCSPD_build_ca_list ( OCSPD_CONFIG *handler,
 			else
 			{
 				// The Server's cert URL is found, let's load the certificate
-				if ((tmp_cert = PKI_X509_CERT_get(tmp_s, -1, NULL, NULL)) == NULL) {
+				if ((tmp_cert = PKI_X509_CERT_get(tmp_s, PKI_DATA_FORMAT_UNKNOWN, NULL, NULL)) == NULL) {
 
 					// Error, can not get the certificate from the URL
 					PKI_log_err("Can not get server's cert [CA: %s, URL: %s]",
@@ -857,7 +857,7 @@ int OCSPD_load_crl ( CA_LIST_ENTRY *ca, OCSPD_CONFIG *conf ) {
 
 	// Load the new CRL
 	if (( ca->crl = PKI_X509_CRL_get_url(ca->crl_url, 
-					     -1, NULL, NULL )) == NULL) {
+					     PKI_DATA_FORMAT_UNKNOWN, NULL, NULL )) == NULL) {
 
 		// Error, can not get the CRL from the URL
 		PKI_log_err("Failed loading CRL for [CA: %s, URL: %s]",
@@ -946,7 +946,7 @@ int ocspd_reload_all_ca ( OCSPD_CONFIG *conf ) {
 
 			// Get the CA certificate
 			if ((ca->ca_cert = PKI_X509_CERT_get_url(ca->ca_url,
-							         -1, NULL, NULL )) == NULL) {
+							         PKI_DATA_FORMAT_UNKNOWN, NULL, NULL )) == NULL) {
 
 				// Can not get the CA Cert from the URL
 				PKI_log_err("Can not load CA cert [CA: %s, URL: %s]",

--- a/src/ocspd/crl.c
+++ b/src/ocspd/crl.c
@@ -49,7 +49,7 @@ int ocspd_load_ca_crl(CA_LIST_ENTRY *caEntry, OCSPD_CONFIG *conf) {
 
 	// We now re-load the CRL
 	if( (caEntry->crl = PKI_X509_CRL_get_url(caEntry->crl_url,
-	                                          -1, NULL, NULL)) == NULL ) {
+	                                          PKI_DATA_FORMAT_UNKNOWN, NULL, NULL)) == NULL ) {
 		PKI_log_err("Can not reload CRL [CA: %s, URL: %s]", 
 						caEntry->ca_id, caEntry->crl_url->url_s);
 		PKI_RWLOCK_release_write(&conf->crl_lock);


### PR DESCRIPTION
This seems to fix #49 with latest libpki